### PR TITLE
Fix linux build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ minitrace_test: $(OBJS)
 	$(CXX) -o $@ $^ ${CFLAGS}
 
 minitrace_test_mt: $(OBJS2)
-	$(CXX) -o $@ $^ ${LDFLAGS}
+	$(CXX) -o $@ $^ -lpthread ${LDFLAGS}
 
 clean:
 	rm -f *.o *.d minitrace_test minitrace_test_mt

--- a/minitrace.c
+++ b/minitrace.c
@@ -184,7 +184,7 @@ const char *mtr_pool_string(const char *str) {
 	int i;
 	for (i = 0; i < STRING_POOL_SIZE; i++) {
 		if (!str_pool[i]) {
-			str_pool[i] = malloc(strlen(str) + 1);
+			str_pool[i] = (char*)malloc(strlen(str) + 1);
 			strcpy(str_pool[i], str);
 			return str_pool[i];
 		} else {
@@ -277,7 +277,7 @@ void mtr_flush() {
 		}
 #endif
 
-		len = snprintf(linebuf, ARRAY_SIZE(linebuf), "%s{\"cat\":\"%s\",\"pid\":%i,\"tid\":%i,\"ts\":%llu,\"ph\":\"%c\",\"name\":\"%s\",\"args\":{%s}%s}",
+		len = snprintf(linebuf, ARRAY_SIZE(linebuf), "%s{\"cat\":\"%s\",\"pid\":%i,\"tid\":%i,\"ts\":%ld,\"ph\":\"%c\",\"name\":\"%s\",\"args\":{%s}%s}",
 				first_line ? "" : ",\n",
 				cat, raw->pid, raw->tid, raw->ts - time_offset, raw->ph, raw->name, arg_buf, id_buf);
 		fwrite(linebuf, 1, len, f);

--- a/minitrace.c
+++ b/minitrace.c
@@ -277,7 +277,7 @@ void mtr_flush() {
 		}
 #endif
 
-		len = snprintf(linebuf, ARRAY_SIZE(linebuf), "%s{\"cat\":\"%s\",\"pid\":%i,\"tid\":%i,\"ts\":%ld,\"ph\":\"%c\",\"name\":\"%s\",\"args\":{%s}%s}",
+		len = snprintf(linebuf, ARRAY_SIZE(linebuf), "%s{\"cat\":\"%s\",\"pid\":%i,\"tid\":%i,\"ts\":%" PRId64 ",\"ph\":\"%c\",\"name\":\"%s\",\"args\":{%s}%s}",
 				first_line ? "" : ",\n",
 				cat, raw->pid, raw->tid, raw->ts - time_offset, raw->ph, raw->name, arg_buf, id_buf);
 		fwrite(linebuf, 1, len, f);


### PR DESCRIPTION
To fix building for linux, I had to link the pthreads.
Also, malloc() result needed to be cast.
An int64_t was printed with %llu which I changed to %ld (Double check if this is still OK on 32b OS'es?)
