### PR TITLE
Add `#pragma once` to simplify usage

### DIFF
--- a/minitrace.h
+++ b/minitrace.h
@@ -18,6 +18,8 @@
 // More:
 // http://www.altdevblogaday.com/2012/08/21/using-chrometracing-to-view-your-inline-profiling-data/
 
+#pragma once
+
 #include <inttypes.h>
 
 // If MTR_ENABLED is not defined, Minitrace does nothing and has near zero overhead.


### PR DESCRIPTION
There are several scenarios where including `minitrace.h` (most probably indirectly) multiple times within the same translation unit is useful. This is a quite non-invasive change that depenalises just that.

For reference, here's a list of compilers and their support for this pragma:
https://en.wikipedia.org/wiki/Pragma_once#Portability
And others will quietly ignore it, which is at least not a detriment. :)