### PR TITLE
Extra warnings from clang

### DIFF
--- a/minitrace.c
+++ b/minitrace.c
@@ -28,6 +28,12 @@
 
 #include "minitrace.h"
 
+#ifdef __GNUC__
+#define ATTR_NORETURN __attribute__((noreturn))
+#else
+#define ATTR_NORETURN
+#endif
+
 #define ARRAY_SIZE(x) sizeof(x)/sizeof(x[0])
 
 // Ugh, this struct is already pretty heavy.
@@ -131,6 +137,7 @@ double mtr_time_s() {
 }
 #endif	// !BLACKBERRY
 
+static void termination_handler(int signum) ATTR_NORETURN;
 static void termination_handler(int signum) {
 	(void) signum;
 	if (is_tracing) {

--- a/minitrace.c
+++ b/minitrace.c
@@ -253,9 +253,10 @@ void mtr_flush() {
 			break;
 		case MTR_ARG_TYPE_STRING_COPY:
 			if (strlen(raw->a_str) > 700) {
-				((char*)raw->a_str)[700] = 0;
+				snprintf(arg_buf, ARRAY_SIZE(arg_buf), "\"%s\":\"%.*s\"", raw->arg_name, 700, raw->a_str);
+			} else {
+				snprintf(arg_buf, ARRAY_SIZE(arg_buf), "\"%s\":\"%s\"", raw->arg_name, raw->a_str);
 			}
-			snprintf(arg_buf, ARRAY_SIZE(arg_buf), "\"%s\":\"%s\"", raw->arg_name, raw->a_str);
 			break;
 		case MTR_ARG_TYPE_NONE:
 		default:

--- a/minitrace.c
+++ b/minitrace.c
@@ -259,7 +259,6 @@ void mtr_flush() {
 			}
 			break;
 		case MTR_ARG_TYPE_NONE:
-		default:
 			arg_buf[0] = '\0';
 			break;
 		}
@@ -382,8 +381,7 @@ void internal_mtr_raw_event_arg(const char *category, const char *name, char ph,
 	case MTR_ARG_TYPE_INT: ev->a_int = (int)(uintptr_t)arg_value; break;
 	case MTR_ARG_TYPE_STRING_CONST:	ev->a_str = (const char*)arg_value; break;
 	case MTR_ARG_TYPE_STRING_COPY: ev->a_str = strdup((const char*)arg_value); break;
-	default:
-		break;
+	case MTR_ARG_TYPE_NONE: break;
 	}
 }
 

--- a/minitrace.h
+++ b/minitrace.h
@@ -38,23 +38,23 @@ extern "C" {
 void mtr_init(const char *json_file);
 
 // Shuts down minitrace cleanly, flushing the trace buffer.
-void mtr_shutdown();
+void mtr_shutdown(void);
 
 // Lets you enable and disable Minitrace at runtime.
 // May cause strange discontinuities in the output.
 // Minitrace is enabled on startup by default.
-void mtr_start();
-void mtr_stop();
+void mtr_start(void);
+void mtr_stop(void);
 
 // Flushes the collected data to disk, clearing the buffer for new data.
-void mtr_flush();
+void mtr_flush(void);
 
 // Returns the current time in seconds. Used internally by Minitrace. No caching.
-double mtr_time_s();
+double mtr_time_s(void);
 
 // Registers a handler that will flush the trace on Ctrl+C.
 // Works on Linux and MacOSX, and in Win32 console applications.
-void mtr_register_sigint_handler();
+void mtr_register_sigint_handler(void);
 
 // Utility function that should rarely be used.
 // If str is semi dynamic, store it permanently in a small pool so we don't need to malloc it.


### PR DESCRIPTION
When compiling a project using minitrace with clang and every warning, here are some issues found:

```
src/minitrace.c:122:8: error: no previous prototype for function 'mtr_time_s' [-Werror,-Wmissing-prototypes]
double mtr_time_s() {
       ^
./src/minitrace.h:53:8: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
double mtr_time_s();
       ^
                  void
src/minitrace.c:134:45: error: function 'termination_handler' could be declared with attribute 'noreturn' [-Werror,-Wmissing-noreturn]
static void termination_handler(int signum) {
                                            ^
src/minitrace.c:145:6: error: no previous prototype for function 'mtr_register_sigint_handler' [-Werror,-Wmissing-prototypes]
void mtr_register_sigint_handler() {
     ^
./src/minitrace.h:57:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void mtr_register_sigint_handler();
     ^
                                 void
src/minitrace.c:171:6: error: no previous prototype for function 'mtr_shutdown' [-Werror,-Wmissing-prototypes]
void mtr_shutdown() {
     ^
./src/minitrace.h:41:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void mtr_shutdown();
     ^
                  void
src/minitrace.c:207:6: error: no previous prototype for function 'mtr_start' [-Werror,-Wmissing-prototypes]
void mtr_start() {
     ^
./src/minitrace.h:46:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void mtr_start();
     ^
               void
src/minitrace.c:214:6: error: no previous prototype for function 'mtr_stop' [-Werror,-Wmissing-prototypes]
void mtr_stop() {
     ^
./src/minitrace.h:47:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void mtr_stop();
     ^
              void
src/minitrace.c:249:13: error: cast from 'const char *' to 'char *' drops const qualifier [-Werror,-Wcast-qual]
                                ((char*)raw->a_str)[700] = 0;
                                        ^
src/minitrace.c:254:3: error: default label in switch which covers all enumeration values [-Werror,-Wcovered-switch-default]
                default:
                ^
src/minitrace.c:222:6: error: no previous prototype for function 'mtr_flush' [-Werror,-Wmissing-prototypes]
void mtr_flush() {
     ^
./src/minitrace.h:50:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void mtr_flush();
     ^
               void
src/minitrace.c:373:10: error: enumeration value 'MTR_ARG_TYPE_NONE' not explicitly handled in switch [-Werror,-Wswitch-enum]
        switch (arg_type) {
                ^
```
10 errors generated.
