### PR TITLE
Fix category string corruption on windows and add a header guard

### DIFF
--- a/minitrace.c
+++ b/minitrace.c
@@ -273,8 +273,8 @@ void mtr_flush() {
 		const char *cat = raw->cat;
 #ifdef _WIN32
 		// On Windows, we often end up with backslashes in category.
+		char temp[256];
 		{
-			char temp[256];
 			int len = (int)strlen(cat);
 			int i;
 			if (len > 255) len = 255;

--- a/minitrace.h
+++ b/minitrace.h
@@ -18,6 +18,9 @@
 // More:
 // http://www.altdevblogaday.com/2012/08/21/using-chrometracing-to-view-your-inline-profiling-data/
 
+#ifndef MINITRACE_H
+#define MINITRACE_H
+
 #include <inttypes.h>
 
 // If MTR_ENABLED is not defined, Minitrace does nothing and has near zero overhead.
@@ -256,6 +259,8 @@ private:
 	const char *category_;
 	const char *name_;
 };
+#endif
+
 #endif
 
 #endif


### PR DESCRIPTION
On windows platform the category string may be corrupted during mtr_flush (and it does always happen with clang), since the pointer to it gets replaced by a stack buffer that goes out of scope right after. The solution is to move the buffer out of scope so that it does not get overwritten.

Also, a header guard has been added to avoid multiple inclusions coming from other headers including the minitrace header.