### PR TITLE
Support initializing minitrace with an externally-provided `FILE` stream

### DIFF
--- a/minitrace.c
+++ b/minitrace.c
@@ -160,19 +160,26 @@ void mtr_register_sigint_handler() {
 
 #endif
 
-void mtr_init(const char *json_file) {
+void mtr_init_from_stream(void *stream) {
 #ifndef MTR_ENABLED
 	return;
 #endif
 	buffer = (raw_event_t *)malloc(INTERNAL_MINITRACE_BUFFER_SIZE * sizeof(raw_event_t));
 	is_tracing = 1;
 	count = 0;
-	f = fopen(json_file, "wb");
+	f = (FILE *)stream;
 	const char *header = "{\"traceEvents\":[\n";
 	fwrite(header, 1, strlen(header), f);
 	time_offset = (uint64_t)(mtr_time_s() * 1000000);
 	first_line = 1;
 	pthread_mutex_init(&mutex, 0);
+}
+
+void mtr_init(const char *json_file) {
+#ifndef MTR_ENABLED
+	return;
+#endif
+	mtr_init_from_stream(fopen(json_file, "wb"));
 }
 
 void mtr_shutdown() {

--- a/minitrace.h
+++ b/minitrace.h
@@ -37,8 +37,12 @@ extern "C" {
 #endif
 
 // Initializes Minitrace. Must be called very early during startup of your executable,
-// before any MTR_ statements..
+// before any MTR_ statements.
 void mtr_init(const char *json_file);
+// Same as above, but allows passing in a custom stream (FILE *), as returned by
+// fopen(). It should be opened for writing, preferably in binary mode to avoid
+// processing of line endings (i.e. the "wb" mode).
+void mtr_init_from_stream(void *stream);
 
 // Shuts down minitrace cleanly, flushing the trace buffer.
 void mtr_shutdown(void);


### PR DESCRIPTION
This is a simple patch that allows passing in an already opened `FILE` stream from the outside, and reimplements `mtr_init()` trivially in terms of the new entry point.

Argument type has been picked as `void *` to avoid polluting the header with all of `#include <stdio>`. It's a trivial change to include it and use `FILE *`, but I think `void *` suits the no-error-checking, you-should-know-what-you're-doing spirit of the library, though.