### PR TITLE
Make minitrace installable via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ project(minitrace)
 add_library(${PROJECT_NAME} STATIC minitrace.c)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR})
-
 option(MTR_ENABLED "Enable minitrace" ON)
 if(MTR_ENABLED)
     target_compile_definitions(${PROJECT_NAME} PUBLIC MTR_ENABLED)
@@ -20,3 +18,18 @@ if(MTR_BUILD_TEST)
     add_executable(minitrace_test_mt minitrace_test_mt.cpp)
     target_link_libraries(minitrace_test_mt ${PROJECT_NAME} Threads::Threads)
 endif()
+
+target_include_directories(${PROJECT_NAME} INTERFACE $<INSTALL_INTERFACE:include>)
+
+install(TARGETS ${PROJECT_NAME} EXPORT minitrace DESTINATION lib)
+install(FILES minitrace.h DESTINATION include)
+install(EXPORT minitrace NAMESPACE minitrace:: FILE "${PROJECT_NAME}Targets.cmake" DESTINATION "share/${PROJECT_NAME}")
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+        INSTALL_DESTINATION "share/${PROJECT_NAME}"
+        NO_SET_AND_CHECK_MACRO
+        NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake" DESTINATION "share/${PROJECT_NAME}")


### PR DESCRIPTION
# Changes
The changes in this PR enable a user to install the library via `cmake --install`. Along with the header and the static library, it also installs CMake export files which allows users to use the library with CMake's `find_package()`.

The necessary CMake code is pretty much taken straight from the CMake guide at https://cmake.org/cmake/help/latest/guide/tutorial/Adding%20Export%20Configuration.html.

I chose the installation prefixes (mostly just the prefix for the CMake exports, which is `share/minitrace`) to conform to the layout that [vcpkg](https://github.com/microsoft/vcpkg) uses.

# How to test
First, build and install minitrace into a directory of your choosing:
```
$ cd minitrace
$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug --install-prefix=<dir>
$ cmake --build build/
$ cmake --install build/
```

This will install minitrace to `<dir>`. Afterwards, you can test the exported CMake targets by creating a new CMake project which imports minitrace:

```cmake
# CMakeLists.txt
cmake_minimum_required(VERSION 3.20)
project(Test)

find_package(minitrace CONFIG REQUIRED)

add_executable(Test main.cpp)
target_link_libraries(TestPUBLIC minitrace::minitrace)
```

When configuring the project, you need to tell CMake where to find the exported CMake files by setting the `CMAKE_PREFIX_PATH` like so:

```
$ cd test-project
$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=<path to installed minitrace>/share/minitrace
```



# Background  
I plan on also opening a PR at the vcpkg repo to update the minitrace port to the latest version. Currently, vcpkg uses an old version from 2019 and supplies its own `CMakeLists.txt` to build and install minitrace. However, they don't define `MTR_ENABLED` when building, resulting in a functionally useless binary. While I investigated that issue, I noticed that minitrace has since added its own `CMakeLists.txt`, so it seemed like a good idea to use that one and remove the custom one in vcpkg. However, vcpkg installs libraries with `cmake --install`, so without the changes in this PR, vcpkg would have to keep (and maintain) their own `CMakeLists.txt`.