### PR TITLE
Allow building minitrace as a shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ endif()
 add_library(${PROJECT_NAME} ${MTR_LIB_TYPE} minitrace.c)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
+target_compile_definitions(${PROJECT_NAME} PUBLIC "MTR_BUILDING_WITH_CMAKE")
+
 option(MTR_ENABLED "Enable minitrace" ON)
 if(MTR_ENABLED)
     target_compile_definitions(${PROJECT_NAME} PUBLIC MTR_ENABLED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,23 @@
 cmake_minimum_required(VERSION 3.10)
 project(minitrace)
 
-add_library(${PROJECT_NAME} STATIC minitrace.c)
+option(MTR_BUILD_SHARED "Build minitrace as a shared library" ${BUILD_SHARED_LIBS})
+if (${MTR_BUILD_SHARED})
+    set(MTR_LIB_TYPE "SHARED")
+else()
+    set(MTR_LIB_TYPE "STATIC")
+endif()
+add_library(${PROJECT_NAME} ${MTR_LIB_TYPE} minitrace.c)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 option(MTR_ENABLED "Enable minitrace" ON)
 if(MTR_ENABLED)
     target_compile_definitions(${PROJECT_NAME} PUBLIC MTR_ENABLED)
 endif()
+
+include(GenerateExportHeader)
+generate_export_header("${PROJECT_NAME}")
+target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
 
 option(MTR_BUILD_TEST "Build test apps" OFF)
 if(MTR_BUILD_TEST)
@@ -22,7 +32,7 @@ endif()
 target_include_directories(${PROJECT_NAME} INTERFACE $<INSTALL_INTERFACE:include>)
 
 install(TARGETS ${PROJECT_NAME} EXPORT minitrace DESTINATION lib)
-install(FILES minitrace.h DESTINATION include)
+install(FILES minitrace.h "${CMAKE_CURRENT_BINARY_DIR}/minitrace_export.h" DESTINATION include)
 install(EXPORT minitrace NAMESPACE minitrace:: FILE "${PROJECT_NAME}Targets.cmake" DESTINATION "share/${PROJECT_NAME}")
 
 include(CMakePackageConfigHelpers)

--- a/minitrace.h
+++ b/minitrace.h
@@ -23,7 +23,11 @@
 
 #include <inttypes.h>
 
+#ifdef MTR_BUILDING_WITH_CMAKE
 #include "minitrace_export.h"
+#else
+#define MINITRACE_EXPORT
+#endif
 
 // If MTR_ENABLED is not defined, Minitrace does nothing and has near zero overhead.
 // Preferably, set this flag in your build system. If you can't just uncomment this line.

--- a/minitrace.h
+++ b/minitrace.h
@@ -23,6 +23,8 @@
 
 #include <inttypes.h>
 
+#include "minitrace_export.h"
+
 // If MTR_ENABLED is not defined, Minitrace does nothing and has near zero overhead.
 // Preferably, set this flag in your build system. If you can't just uncomment this line.
 // #define MTR_ENABLED
@@ -38,36 +40,36 @@ extern "C" {
 
 // Initializes Minitrace. Must be called very early during startup of your executable,
 // before any MTR_ statements.
-void mtr_init(const char *json_file);
+MINITRACE_EXPORT void mtr_init(const char *json_file);
 // Same as above, but allows passing in a custom stream (FILE *), as returned by
 // fopen(). It should be opened for writing, preferably in binary mode to avoid
 // processing of line endings (i.e. the "wb" mode).
-void mtr_init_from_stream(void *stream);
+MINITRACE_EXPORT void mtr_init_from_stream(void *stream);
 
 // Shuts down minitrace cleanly, flushing the trace buffer.
-void mtr_shutdown(void);
+MINITRACE_EXPORT void mtr_shutdown(void);
 
 // Lets you enable and disable Minitrace at runtime.
 // May cause strange discontinuities in the output.
 // Minitrace is enabled on startup by default.
-void mtr_start(void);
-void mtr_stop(void);
+MINITRACE_EXPORT void mtr_start(void);
+MINITRACE_EXPORT void mtr_stop(void);
 
 // Flushes the collected data to disk, clearing the buffer for new data.
-void mtr_flush(void);
+MINITRACE_EXPORT void mtr_flush(void);
 
 // Returns the current time in seconds. Used internally by Minitrace. No caching.
-double mtr_time_s(void);
+MINITRACE_EXPORT double mtr_time_s(void);
 
 // Registers a handler that will flush the trace on Ctrl+C.
 // Works on Linux and MacOSX, and in Win32 console applications.
-void mtr_register_sigint_handler(void);
+MINITRACE_EXPORT void mtr_register_sigint_handler(void);
 
 // Utility function that should rarely be used.
 // If str is semi dynamic, store it permanently in a small pool so we don't need to malloc it.
 // The pool fills up fast though and performance isn't great.
 // Returns a fixed string if the pool is full.
-const char *mtr_pool_string(const char *str);
+MINITRACE_EXPORT const char *mtr_pool_string(const char *str);
 
 // Commented-out types will be supported in the future.
 typedef enum {
@@ -85,8 +87,8 @@ typedef enum {
 #define MTR_MAX_ARGS 1
 
 // Only use the macros to call these.
-void internal_mtr_raw_event(const char *category, const char *name, char ph, void *id);
-void internal_mtr_raw_event_arg(const char *category, const char *name, char ph, void *id, mtr_arg_type arg_type, const char *arg_name, void *arg_value);
+MINITRACE_EXPORT void internal_mtr_raw_event(const char *category, const char *name, char ph, void *id);
+MINITRACE_EXPORT void internal_mtr_raw_event_arg(const char *category, const char *name, char ph, void *id, mtr_arg_type arg_type, const char *arg_name, void *arg_value);
 
 #ifdef MTR_ENABLED
 


### PR DESCRIPTION
This PR allows users to build minitrace as a shared library via CMake by setting the option `MTR_BUILD_SHARED` to `ON`. This option defaults to the value of `BUILD_SHARED_LIBS`.

Closes #35 