### PR TITLE
Fix: Add Config.cmake.in to VCS

### DIFF
--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INI@
+
+include("${CMAKE_CURRENT_LIST_DIR}/minitraceTargets.cmake")


### PR DESCRIPTION
It appears I made a little mistake with https://github.com/hrydgard/minitrace/pull/34 and forgot to add `Config.cmake.in` to Git. Sorry for that.