### PR TITLE
Use CMakes default install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 
 target_include_directories(${PROJECT_NAME} INTERFACE $<INSTALL_INTERFACE:include>)
 
-install(TARGETS ${PROJECT_NAME} EXPORT minitrace DESTINATION lib)
+install(TARGETS ${PROJECT_NAME} EXPORT minitrace)
 install(FILES minitrace.h "${CMAKE_CURRENT_BINARY_DIR}/minitrace_export.h" DESTINATION include)
 install(EXPORT minitrace NAMESPACE minitrace:: FILE "${PROJECT_NAME}Targets.cmake" DESTINATION "share/${PROJECT_NAME}")
 


### PR DESCRIPTION
When I followed the CMake tutorial for exporting the library, I also copied its behaviour of explicitly specifying `lib/` as the destination for the binary. However, this was not entirely correct: On Windows, DLLs should be placed in `bin/`, not `lib/`. Luckily, the [vcpkg CI pipeline run for my PR](https://github.com/microsoft/vcpkg/pull/31069) caught this error.

Consequently, this PR removes the explicit destination and lets CMake use its builtin defaults which are documented [in the section for `install(TARGETS)`](https://cmake.org/cmake/help/latest/command/install.html#targets).