### PR TITLE
Fix flush_buffer memory leak

### DIFF
--- a/minitrace.c
+++ b/minitrace.c
@@ -210,6 +210,8 @@ void mtr_shutdown() {
 	f = 0;
 	free(event_buffer);
 	event_buffer = 0;
+	free(flush_buffer);
+	flush_buffer = 0;
 	for (i = 0; i < STRING_POOL_SIZE; i++) {
 		if (str_pool[i]) {
 			free(str_pool[i]);


### PR DESCRIPTION
Inside mtr_init_from_stream, malloc is called on the flush_buffer, which is not released in mtr_shutdown. The result is about 64000000 bytes of memory leak, which this change patches.
> Detected memory leaks!
Dumping objects ->
{83} normal block at 0x000002797A340070, 64000000 bytes long.
 Data: <                > CD CD CD CD CD CD CD CD CD CD CD CD CD CD CD CD 
Object dump complete.