### PR TITLE
Set is_flushing to FALSE in mtr_init_from_stream

### DIFF
--- a/minitrace.c
+++ b/minitrace.c
@@ -175,6 +175,7 @@ void mtr_init_from_stream(void *stream) {
 #endif
 	event_buffer = (raw_event_t *)malloc(INTERNAL_MINITRACE_BUFFER_SIZE * sizeof(raw_event_t));
 	flush_buffer = (raw_event_t *)malloc(INTERNAL_MINITRACE_BUFFER_SIZE * sizeof(raw_event_t));
+	is_flushing = FALSE;
 	is_tracing = 1;
 	event_count = 0;
 	f = (FILE *)stream;


### PR DESCRIPTION
Hi,
this PR sets is_flushing to FALSE in mtr_init_from_stream.
The problem was that it was not possible to call init+shutdown multiple times - is_flushing is set to TRUE in shutdown, so another mtr_init call and trying to add traces had no effect (traces were not added to the file due to an early return in mtr_flush_with_state function). It has been done like this probably so that it is not possible to perform flush after mtr_shutdown. However, such approach makes it impossible to properly reinitialize the tracer. Settings is_flushing to FALSE in mtr_init_from_stream, adds the ability to call init+shutdown multiple times. Thanks to this, it is possible to create many traces files in the same run of the application.