### PR TITLE
Cast a double value that stores a duration to int64_t instead of int

### DIFF
--- a/minitrace.c
+++ b/minitrace.c
@@ -325,7 +325,7 @@ void mtr_flush_with_state(int is_last) {
 				snprintf(id_buf, ARRAY_SIZE(id_buf), ",\"id\":\"0x%08x\"", (uint32_t)(uintptr_t)raw->id);
 				break;
 			case 'X':
-				snprintf(id_buf, ARRAY_SIZE(id_buf), ",\"dur\":%i", (int)raw->a_double);
+				snprintf(id_buf, ARRAY_SIZE(id_buf), ",\"dur\":%" PRId64, (int64_t)raw->a_double);
 				break;
 			}
 		} else {


### PR DESCRIPTION
The problem was that using int caused overflow if the function took more than 2147 seconds to execute. 
Example: `{"cat":"some_category","pid":1788,"tid":7504,"ts":42561811891,"ph":"X","name":"some_function","args":{},"dur":-2147483648}`
The new solution for "dur" uses the same approach we had for "ts".